### PR TITLE
A2I + Rekognition and A2I + Textract Notebook Improvements

### DIFF
--- a/Amazon Augmented AI (A2I) and Rekognition DetectModerationLabels.ipynb
+++ b/Amazon Augmented AI (A2I) and Rekognition DetectModerationLabels.ipynb
@@ -236,11 +236,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "WORKTEAM_ARN= \"<YOUR_WORKTEAM_ARN>\""
+    "WORKTEAM_ARN = \"<YOUR_WORKTEAM_ARN>\""
    ]
   },
   {

--- a/Amazon Augmented AI (A2I) and Rekognition DetectModerationLabels.ipynb
+++ b/Amazon Augmented AI (A2I) and Rekognition DetectModerationLabels.ipynb
@@ -82,6 +82,7 @@
    "source": [
     "# First, let's get the latest installations of our dependencies\n",
     "!pip install --upgrade pip\n",
+    "!pip install botocore --upgrade\n",
     "!pip install boto3 --upgrade\n",
     "!pip install -U botocore"
    ]
@@ -106,8 +107,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Region\n",
-    "REGION = '<REGION>'"
+    "import boto3\n",
+    "import botocore\n",
+    "\n",
+    "REGION = boto3.session.Session().region_name"
    ]
   },
   {
@@ -123,11 +126,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import boto3\n",
-    "import botocore\n",
-    "\n",
     "BUCKET = '<YOUR_BUCKET>'\n",
     "OUTPUT_PATH = f's3://{BUCKET}/a2i-results'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your bucket, `BUCKET` must be located in the same AWS Region that you are using to run this notebook. This cell checks if they are located in the same Region. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Amazon S3 (S3) client\n",
+    "s3 = boto3.client('s3', REGION)\n",
+    "bucket_region = s3.head_bucket(Bucket=BUCKET)['ResponseMetadata']['HTTPHeaders']['x-amz-bucket-region']\n",
+    "assert bucket_region == REGION, \"Your S3 bucket {} and this notebook need to be in the same region.\".format(BUCKET)"
    ]
   },
   {
@@ -140,7 +159,33 @@
     "\n",
     "* RekognitionFullAccess\n",
     "* SagemakerFullAccess\n",
-    "* S3 Read Access to the bucket listed below\n",
+    "* S3 Read and Write Access to the bucket you specified in `BUCKET`. You can grant this permission by attaching a policy similar to the following to this role (replace `BUCKET` with your bucket-name).\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "    \"Version\": \"2012-10-17\",\n",
+    "    \"Statement\": [\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:GetObject\"\n",
+    "            ],\n",
+    "            \"Resource\": [\n",
+    "                \"arn:aws:s3:::BUCKET/*\"\n",
+    "            ]\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:PutObject\"\n",
+    "            ],\n",
+    "            \"Resource\": [\n",
+    "                \"arn:aws:s3:::BUCKET/*\"\n",
+    "            ]\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "```\n",
     "* AmazonSageMakerMechanicalTurkAccess (if using MechanicalTurk as your Workforce)"
    ]
   },
@@ -191,11 +236,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "WORKTEAM_ARN= \"<YOUR_WORKTEAM>\""
+    "WORKTEAM_ARN= \"<YOUR_WORKTEAM_ARN>\""
    ]
   },
   {
@@ -803,9 +848,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3.7.4 64-bit ('base': conda)",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python_defaultSpec_1596228949438"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Amazon Augmented AI (A2I) and Textract AnalyzeDocument.ipynb
+++ b/Amazon Augmented AI (A2I) and Textract AnalyzeDocument.ipynb
@@ -82,6 +82,7 @@
    "source": [
     "# First, let's get the latest installations of our dependencies\n",
     "!pip install --upgrade pip\n",
+    "!pip install botocore --upgrade\n",
     "!pip install boto3 --upgrade\n",
     "!pip install -U botocore"
    ]
@@ -106,15 +107,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Region\n",
-    "REGION = '<REGION>'"
+    "import boto3\n",
+    "import botocore\n",
+    "\n",
+    "REGION = boto3.session.Session().region_name"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Setup Bucket and Paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "### Workteam or Workforce"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your bucket, `BUCKET` must be located in the same AWS Region that you are using to run this notebook. This cell checks if they are located in the same Region. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Amazon S3 (S3) client\n",
+    "s3 = boto3.client('s3', REGION)\n",
+    "bucket_region = s3.head_bucket(Bucket=BUCKET)['ResponseMetadata']['HTTPHeaders']['x-amz-bucket-region']\n",
+    "assert bucket_region == REGION, \"Your S3 bucket {} and this notebook need to be in the same region.\".format(BUCKET)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T_PATH = f's3://{BUCKET}/a2i-results'z"
    ]
   },
   {
@@ -148,33 +188,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Setup Bucket and Paths"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import boto3\n",
-    "import botocore\n",
-    "\n",
-    "BUCKET = '<YOUR_BUCKET>'\n",
-    "OUTPUT_PATH = f's3://{BUCKET}/a2i-results'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Permissions\n",
     "\n",
     "The AWS IAM Role used to execute the notebook needs to have the following permissions:\n",
     "\n",
     "* TextractFullAccess\n",
     "* SagemakerFullAccess\n",
-    "* S3 Read Access to the bucket listed below\n",
+    "* S3 Read and Write Access to the bucket you specified in `BUCKET`. You can grant this permission by attaching a policy similar to the following to this role (replace `BUCKET` with your bucket-name).\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "    \"Version\": \"2012-10-17\",\n",
+    "    \"Statement\": [\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:GetObject\"\n",
+    "            ],\n",
+    "            \"Resource\": [\n",
+    "                \"arn:aws:s3:::BUCKET/*\"\n",
+    "            ]\n",
+    "        },\n",
+    "        {\n",
+    "            \"Effect\": \"Allow\",\n",
+    "            \"Action\": [\n",
+    "                \"s3:PutObject\"\n",
+    "            ],\n",
+    "            \"Resource\": [\n",
+    "                \"arn:aws:s3:::BUCKET/*\"\n",
+    "            ]\n",
+    "        }\n",
+    "    ]\n",
+    "}\n",
+    "```\n",
     "* AmazonSageMakerMechanicalTurkAccess (if using MechanicalTurk as your Workforce)"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*
* Error appears when pip-installing and upgrading packages 
* Error uploading to S3 because the notebook does not instruct user to add S3 PUT permission to IAM role used 

*Description of changes:*
* Fixed error that appears when pip-installing and upgrading packages by adding botocore
* Fixed error when uploading to S3 by adding requirement that customers add S3 "put" permissions to their role. 
* Automated determination of the AWS Region
* Added check that bucket and notebook were located in the same AWS Region. 

*Testing:*
* Tested the notebook E2E after making these changes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
