### PR TITLE
Documentation: adding CORS permission requirement note to notebooks t…

### DIFF
--- a/Amazon A2I with Amazon SageMaker for object detection and model retraining.ipynb
+++ b/Amazon A2I with Amazon SageMaker for object detection and model retraining.ipynb
@@ -142,7 +142,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Setup Bucket and Paths"
+    "#### Setup Bucket and Paths\n",
+    "\n",
+    "**Important**: The bucket you specify for `BUCKET` must have CORS enabled. You can enable CORS by adding a policy similar to the following to your Amazon S3 bucket. To learn how to add CORS to an S3 bucket, see [CORS Permission Requirement](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-permissions-security.html#a2i-cors-update) in the Amazon A2I documentation. \n",
+    "\n",
+    "\n",
+    "```\n",
+    "[{\n",
+    "   \"AllowedHeaders\": [],\n",
+    "   \"AllowedMethods\": [\"GET\"],\n",
+    "   \"AllowedOrigins\": [\"*\"],\n",
+    "   \"ExposeHeaders\": []\n",
+    "}]\n",
+    "```\n",
+    "\n",
+    "If you do not add a CORS configuration to the S3 buckets that contains your image input data, human review tasks for those input data objects will fail. \n"
    ]
   },
   {

--- a/Amazon Augmented AI (A2I) and Rekognition DetectModerationLabels.ipynb
+++ b/Amazon Augmented AI (A2I) and Rekognition DetectModerationLabels.ipynb
@@ -117,7 +117,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Setup Bucket and Paths"
+    "#### Setup Bucket and Paths\n",
+    "\n",
+    "**Important**: The bucket you specify for `BUCKET` must have CORS enabled. You can enable CORS by adding a policy similar to the following to your Amazon S3 bucket. To learn how to add CORS to an S3 bucket, see [CORS Permission Requirement](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-permissions-security.html#a2i-cors-update) in the Amazon A2I documentation. \n",
+    "\n",
+    "\n",
+    "```\n",
+    "[{\n",
+    "   \"AllowedHeaders\": [],\n",
+    "   \"AllowedMethods\": [\"GET\"],\n",
+    "   \"AllowedOrigins\": [\"*\"],\n",
+    "   \"ExposeHeaders\": []\n",
+    "}]\n",
+    "```\n",
+    "\n",
+    "If you do not add a CORS configuration to the S3 buckets that contains your image input data, human review tasks for those input data objects will fail. \n",
+    "\n"
    ]
   },
   {

--- a/Amazon Augmented AI (A2I) and Textract AnalyzeDocument.ipynb
+++ b/Amazon Augmented AI (A2I) and Textract AnalyzeDocument.ipynb
@@ -117,7 +117,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Setup Bucket and Paths"
+    "#### Setup Bucket and Paths\n",
+    "\n",
+    "**Important**: The bucket you specify for `BUCKET` must have CORS enabled. You can enable CORS by adding a policy similar to the following to your Amazon S3 bucket. To learn how to add CORS to an S3 bucket, see [CORS Permission Requirement](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-permissions-security.html#a2i-cors-update) in the Amazon A2I documentation. \n",
+    "\n",
+    "\n",
+    "```\n",
+    "[{\n",
+    "   \"AllowedHeaders\": [],\n",
+    "   \"AllowedMethods\": [\"GET\"],\n",
+    "   \"AllowedOrigins\": [\"*\"],\n",
+    "   \"ExposeHeaders\": []\n",
+    "}]\n",
+    "```\n",
+    "\n",
+    "If you do not add a CORS configuration to the S3 buckets that contains your image input data, human review tasks for those input data objects will fail. \n"
    ]
   },
   {

--- a/Amazon-A2I-Rekognition-Custom-Label-notebook.ipynb
+++ b/Amazon-A2I-Rekognition-Custom-Label-notebook.ipynb
@@ -66,6 +66,33 @@
    ]
   },
   {
+   "source": [
+    "### Initialize Variables\n",
+    "\n",
+    "Use the following cell to specify:\n",
+    "* `WORKTEAM_ARN` : the Amazon Resource Name (ARN) of the private work team you want to use for this walkthrough.\n",
+    "* `BUCKET` : The Amazon S3 bucket you want to use to store input and output data. This bucket must have CORS enabled (see note below).\n",
+    "*  `REGION` : The AWS Region your notebook instance, `BUCKET` and work team are located in. Note that these resources must be located in the same AWS Region.\n",
+    "\n",
+    "**Important**: The bucket you specify for `BUCKET` must have CORS enabled. You can enable CORS by adding a policy similar to the following to your Amazon S3 bucket. To learn how to add CORS to an S3 bucket, see [CORS Permission Requirement](https://docs.aws.amazon.com/sagemaker/latest/dg/a2i-permissions-security.html#a2i-cors-update) in the Amazon A2I documentation. \n",
+    "\n",
+    "\n",
+    "```\n",
+    "[{\n",
+    "   \"AllowedHeaders\": [],\n",
+    "   \"AllowedMethods\": [\"GET\"],\n",
+    "   \"AllowedOrigins\": [\"*\"],\n",
+    "   \"ExposeHeaders\": []\n",
+    "}]\n",
+    "```\n",
+    "\n",
+    "If you do not add a CORS configuration to the S3 buckets that contains your image input data, human review tasks for those input data objects will fail. \n",
+    "\n"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION

*Description of changes:*

* Image based human review tasks will fail if customers do not add CORS configuration to S3 buckets that contain input data. Adding a note that input image buckets must contain CORS, and providing a resource to help users add a CORS configuration to their S3 buckets. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
